### PR TITLE
Ignore `extern crate {core, alloc, std};`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@
 
     Previously, cargo-equip tried to `check` all of the packages with `custom-build` and failed.
 
+- `extern crate {core, alloc, std};` will be just ignored.
+
 ## [0.8.0] - 2020-11-13Z
 
 ### Changed

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -397,6 +397,10 @@ pub(crate) fn process_extern_crates_in_lib(
                 ..
             } = item_use;
 
+            if ["core", "alloc", "std"].contains(&&*ident.to_string()) {
+                return;
+            }
+
             let to = match (self.convert_extern_crate_name)(ident) {
                 Ok(to) => Ident::new(&to, Span::call_site()),
                 Err(err) => {


### PR DESCRIPTION
Closes #56.

bors r+
