### PR TITLE
Make inserting `#![allow(unused_imports)]` optional

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,7 @@ pub enum Opt {
         )]
         oneline: Minify,
 
+        /// Insert `#![allow(unused_imports)]`
         #[structopt(long)]
         allow_unused_imports: bool,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,9 @@ pub enum Opt {
         )]
         oneline: Minify,
 
+        #[structopt(long)]
+        allow_unused_imports: bool,
+
         /// Format the output before emitting
         #[structopt(long)]
         rustfmt: bool,
@@ -242,6 +245,7 @@ pub fn run(opt: Opt, ctx: Context<'_>) -> anyhow::Result<()> {
         remove,
         minify,
         oneline,
+        allow_unused_imports,
         rustfmt,
         check,
         output,
@@ -336,6 +340,7 @@ pub fn run(opt: Opt, ctx: Context<'_>) -> anyhow::Result<()> {
         resolve_cfgs,
         &remove,
         minify,
+        allow_unused_imports,
         rustfmt,
         &cache_dir,
         shell,
@@ -372,6 +377,7 @@ fn bundle(
     resolve_cfgs: bool,
     remove: &[Remove],
     minify: Minify,
+    allow_unused_imports: bool,
     rustfmt: bool,
     cache_dir: &Path,
     shell: &mut Shell,
@@ -785,7 +791,7 @@ fn bundle(
             }
 
             doc
-        })?;
+        }, allow_unused_imports)?;
 
         code += "\n";
         code += "// The following code was expanded by `cargo-equip`.\n";


### PR DESCRIPTION
In #126, `#![allow(unused_imports)]` attribute is always inserted in the top of every bundled code.

As one of the user, I would prefer to write the attribute by myself because of ignore the unused warnings than to be bundled automatically and duplicated.

# Changes

- add `allow-unused-imports` flag to `Opt`
- fix `rust::prepend_items` to insert `#![allow(unused_imports)]` when `--allow-unused-imports` is given.