### PR TITLE
Use the `2021-07-12` RA for Rust 1.47, `2021-08-09` RA for Rust 1.48+ 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
      }
     ```
 
-- Updated rust-analyzer to `2021-07-26`. ([#155](https://github.com/qryxip/cargo-equip/pull/155))
+- Now uses rust-analyzer `2021-07-12` for Rust 1.47 and `2021-08-09` for Rust 1.48+.
 
 ### Fixed
 


### PR DESCRIPTION
Workaround for #162.

Closes #162.