### PR TITLE
Remove `difference` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,9 +74,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bitflags"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da1976d75adbe5fbc88130ecd119529cf1cc6a93ae1546d8696ee66f0d21af1"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "blake2b_simd"
@@ -467,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1b21a2971cea49ca4613c0e9fe8225ecaf5de64090fddc6002284726e9244"
+checksum = "58019516c1403ac45b106c9fc4e8fcbd77a78e98b014c619d1506338902ccfa4"
 dependencies = [
  "console",
  "lazy_static",
@@ -515,9 +515,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
+checksum = "a1fa8cddc8fbbee11227ef194b5317ed014b8acbf15139bd716a18ad3fe99ec5"
 
 [[package]]
 name = "libflate"
@@ -559,9 +559,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "num-integer"
@@ -615,9 +615,9 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "predicates"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc3d91237f5de3bcd9d927e24d03b495adb6135097b001cea7403e2d573d00a9"
+checksum = "c143348f141cc87aab5b950021bac6145d0e5ae754b0591de23244cee42c9308"
 dependencies = [
  "difflib",
  "itertools",
@@ -891,9 +891,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.17"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23"
+checksum = "039ba818c784248423789eec090aab9fb566c7b94d6ebbfa1814a9fd52c8afb2"
 dependencies = [
  "dtoa",
  "linked-hash-map",
@@ -930,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "spdx"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f6a7041c8f5ef47b1bf43eee1adc338506f237207917ca19810c2e7a42f9e1"
+checksum = "04add55f596508726f5ef009818259081075b7130dcf9b5d03dce7e269f23c76"
 dependencies = [
  "smallvec",
 ]
@@ -969,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.74"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
+checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,7 +142,6 @@ dependencies = [
  "cargo_metadata",
  "cfg-expr",
  "derive_more",
- "difference",
  "dirs-next",
  "fixedbitset",
  "if_chain",
@@ -146,6 +154,7 @@ dependencies = [
  "md5",
  "once_cell",
  "petgraph",
+ "pretty_assertions",
  "prettytable-rs",
  "proc-macro2",
  "quote",
@@ -222,7 +231,7 @@ version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim",
@@ -308,6 +317,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,10 +340,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "difference"
-version = "2.0.0"
+name = "diff"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
 name = "difflib"
@@ -589,6 +608,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
+name = "output_vt100"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "pest"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +666,18 @@ checksum = "d7dd0fd014130206c9352efbdc92be592751b2b9274dff685348341082c6ea3d"
 dependencies = [
  "predicates-core",
  "treeline",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b"
+dependencies = [
+ "ansi_term 0.12.1",
+ "ctor",
+ "diff",
+ "output_vt100",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,6 @@ xshell = "0.1.14"
 
 [dev-dependencies]
 assert_cmd = "2.0.0"
-difference = "2.0.0"
 insta = "1.7.2"
 md5 = "0.7.0"
+pretty_assertions = "0.7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,9 @@ serde = { version = "1.0.127", features = ["derive"] }
 serde_json = "1.0.66"
 shell-escape = "0.1.5"
 smol_str = { version = "0.1.18", features = ["serde"] }
-spdx = "0.5.0"
+spdx = "0.6.0"
 structopt = "0.3.22"
-syn = { version = "1.0.74", features = ["extra-traits", "full", "parsing", "visit"] }
+syn = { version = "1.0.75", features = ["extra-traits", "full", "parsing", "visit"] }
 tempfile = "3.2.0"
 termcolor = "1.1.2"
 toml_edit = "0.2.1"
@@ -47,5 +47,5 @@ xshell = "0.1.14"
 [dev-dependencies]
 assert_cmd = "2.0.0"
 difference = "2.0.0"
-insta = "1.7.1"
+insta = "1.7.2"
 md5 = "0.7.0"

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -1792,7 +1792,7 @@ impl<'opt> CodeEdit<'opt> {
 #[cfg(test)]
 mod tests {
     use crate::rust::CodeEdit;
-    use difference::assert_diff;
+    use pretty_assertions::assert_eq;
     use proc_macro2::Span;
     use syn::Ident;
 
@@ -1806,7 +1806,7 @@ mod tests {
             DUMMY_MOD_NAME.with(|dummy_mod_name| {
                 let mut edit = CodeEdit::from_code(dummy_mod_name, input)?;
                 edit.erase_docs()?;
-                assert_diff!(expected, &edit.finish()?, "\n", 0);
+                assert_eq!(expected, edit.finish()?);
                 Ok(())
             })
         }
@@ -1844,7 +1844,7 @@ fn foo() {}
             DUMMY_MOD_NAME.with(|dummy_mod_name| {
                 let mut edit = CodeEdit::from_code(dummy_mod_name, input)?;
                 edit.erase_comments()?;
-                assert_diff!(expected, &edit.finish()?, "\n", 0);
+                assert_eq!(expected, edit.finish()?);
                 Ok(())
             })
         }


### PR DESCRIPTION
Removes `difference` as it is [unmaintained](https://rustsec.org/advisories/RUSTSEC-2020-0095.html).
