### PR TITLE
Disable `test` flag for `lib`/`bin` crates when checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,14 @@
 
 - (also applied to the previous versions unless `--locked`) Updated [syn](https://docs.rs/crate/syn) to v1.0.76.
 
-    - [Now accepts some nightly-only syntax](https://github.com/dtolnay/syn/pull/1070).
+    - [Now accepts some nightly-only syntaxes](https://github.com/dtolnay/syn/pull/1070).
     - [Now accepts trailing `+` in _TypeParamBounds_](https://github.com/dtolnay/syn/pull/1074).
+
+### Fixed
+
+- Now outputs from `lib`/`bin` crates are `check`ed without `test` flag.
+
+    Previously, `#[test]`s without `#[cfg(test)]` are unintentionally `check`ed.
 
 ## [0.18.0] - 2021-09-07Z
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Added
 
+- (also applied to the previous versions unless `--locked`) Updated [syn](https://docs.rs/crate/syn) to v1.0.76.
+
+    - [Now accepts some nightly-only syntax](https://github.com/dtolnay/syn/pull/1070).
+    - [Now accepts trailing `+` in _TypeParamBounds_](https://github.com/dtolnay/syn/pull/1074).
+
+## [0.18.0] - 2021-09-07Z
+
+### Added
+
 - Added `--mod-path <MODULE_PATH>` option. ([#159](https://github.com/qryxip/cargo-equip/pull/159))
 
     ```diff

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -644,6 +644,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kstring"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e8d7e992938cc9078c8db5fd5bdc400e7f9da6efa384c280902a8922b676221"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,9 +660,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.102"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
+checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
 
 [[package]]
 name = "libflate"
@@ -739,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.66"
+version = "0.9.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1996d2d305e561b70d1ee0c53f1542833f4e1ac6ce9a6708b6ff2738ca67dc82"
+checksum = "69df2d8dfc6ce3aaf44b40dec6f487d5a886516cf6879c49e98e0710f310a058"
 dependencies = [
  "autocfg",
  "cc",
@@ -780,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+checksum = "7c9b1041b4387893b91ee6746cddfc28516aff326a3519fb2adf820932c5e6cb"
 
 [[package]]
 name = "ppv-lite86"
@@ -819,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "pretty_assertions"
-version = "0.7.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b"
+checksum = "ec0cfe1b2403f172ba0f234e500906ee0a3e493fb81092dac23ebefe129301cc"
 dependencies = [
  "ansi_term 0.12.1",
  "ctor",
@@ -1113,9 +1122,9 @@ checksum = "1ad1d488a557b235fc46dae55512ffbfc429d2482b08b4d9435ab07384ca8aec"
 
 [[package]]
 name = "smallvec"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "smol_str"
@@ -1167,9 +1176,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
+checksum = "a4eac2e6c19f5c3abc0c229bea31ff0b9b091c7b14990e8924b92902a303a0c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1231,14 +1240,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30834716e93eef7db510648299f647427858e7e2c0beeec2699ea2289c7739"
+checksum = "e0a0ddb4919e3b49fe9e08e7921d69445bb00ce95a2ea807bb8826cde6610455"
 dependencies = [
  "combine",
  "indexmap",
  "itertools",
- "vec1",
+ "kstring",
 ]
 
 [[package]]
@@ -1261,9 +1270,9 @@ checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
@@ -1288,12 +1297,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec1"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc1631c774f0f9570797191e01247cbefde789eebfbf128074cb934115a6133"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,14 +37,14 @@ serde_json = "1.0.68"
 smol_str = { version = "0.1.18", features = ["serde"] }
 spdx = "0.6.0"
 structopt = "0.3.23"
-syn = { version = "1.0.76", features = ["extra-traits", "full", "parsing", "visit"] }
+syn = { version = "1.0.78", features = ["extra-traits", "full", "parsing", "visit"] }
 tempfile = "3.2.0"
 termcolor = "1.1.2"
-toml_edit = "0.3.1"
+toml_edit = "0.5.0"
 which = "4.2.2"
 
 [dev-dependencies]
 assert_cmd = "2.0.1"
 insta = "1.8.0"
 md5 = "0.7.0"
-pretty_assertions = "0.7.2"
+pretty_assertions = "1.0.0"

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -215,7 +215,13 @@ pub(crate) fn cargo_check_using_current_lockfile_and_cache(
         .arg(&metadata.target_directory)
         .arg("--manifest-path")
         .arg(temp_pkg.path().join("Cargo.toml"))
-        .arg("--all-targets")
+        .args(&if target.is_bin() {
+            vec!["--bin", crate_name]
+        } else if target.is_example() {
+            vec!["--example", crate_name]
+        } else {
+            vec!["--lib"]
+        })
         .arg("--offline")
         .cwd(&metadata.workspace_root)
         .exec()?;


### PR DESCRIPTION
Fixes #176.