### PR TITLE
Support for 0BSD license

### DIFF
--- a/src/workspace/license.rs
+++ b/src/workspace/license.rs
@@ -204,7 +204,7 @@ fn read(package: &cm::Package, cache_dir: &Path) -> Result<Option<String>, Vec<S
 
     let is = |name| license.evaluate(|r| r.license.id() == spdx::license_id(name));
 
-    if is("CC0-1.0") || is("Unlicense") {
+    if is("0BSD") || is("CC0-1.0") || is("Unlicense") {
         return Ok(None);
     }
 


### PR DESCRIPTION
[0BSD](https://opensource.org/license/0bsd/) is a public domain equivalent license, and it is OSI-approved. This change lets cargo-equip treat it in the same way as it does with CC0-1.0 and Unlicense.